### PR TITLE
docs: add introduction section and improve content structure

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -11,7 +11,14 @@ export default defineConfig({
 			social: [{ icon: 'github', label: 'GitHub', href: 'https://github.com/forkspacer' }],
 			sidebar: [
 				{
-					label: 'Guides',
+					label: 'Introduction',
+					items: [
+						{ label: 'What is Forkspacer?', link: '/introduction/overview/' },
+						{ label: 'Core Concepts', link: '/introduction/concepts/' },
+					],
+				},
+				{
+					label: 'Getting Started',
 					autogenerate: { directory: 'guides' },
 				},
 				{

--- a/src/content/docs/development/custom-module.md
+++ b/src/content/docs/development/custom-module.md
@@ -5,8 +5,6 @@ sidebar:
   order: 2
 ---
 
-# Custom Module Development
-
 Forkspacer supports custom modules that allow you to extend the operator with custom resource management logic. Custom modules enable you to integrate third-party tools, implement custom deployment strategies, or handle specialized workloads beyond the built-in Helm support.
 
 ## What are Custom Modules?
@@ -32,6 +30,7 @@ Custom modules expose an HTTP server that the operator calls to manage Module li
 #### Required Endpoints
 
 **Health Check:**
+
 ```
 GET /health
 Response: 200 OK
@@ -44,6 +43,7 @@ Response: 200 OK
 ```
 
 **Install:**
+
 ```
 POST /install
 Content-Type: application/json
@@ -52,6 +52,7 @@ Response: 201 Created (on success) or 400 Bad Request (on failure)
 ```
 
 **Uninstall:**
+
 ```
 POST /uninstall
 Content-Type: application/json
@@ -60,6 +61,7 @@ Response: 204 No Content (on success) or 400 Bad Request (on failure)
 ```
 
 **Sleep:**
+
 ```
 POST /sleep
 Content-Type: application/json
@@ -68,6 +70,7 @@ Response: 200 OK (on success) or 400 Bad Request (on failure)
 ```
 
 **Resume:**
+
 ```
 POST /resume
 Content-Type: application/json
@@ -95,6 +98,7 @@ go mod init my-module
 ```
 
 **Example `go.mod`:**
+
 ```go
 module my-module
 
@@ -724,6 +728,7 @@ func (h *Handler) Health(w http.ResponseWriter, r *http.Request) {
 ## Complete Example
 
 See the complete example custom module in the repository:
+
 - [Example Custom Module](https://github.com/forkspacer/modules/tree/main/custom/example)
 
 ## Next Steps

--- a/src/content/docs/development/overview.md
+++ b/src/content/docs/development/overview.md
@@ -5,8 +5,6 @@ sidebar:
   order: 1
 ---
 
-# Development Overview
-
 This guide covers the development workflow for contributing to the Forkspacer operator, including setting up your development environment, building, testing, and running the operator locally.
 
 ## Prerequisites
@@ -61,11 +59,13 @@ make dev-host
 ```
 
 This runs the operator against your current kubeconfig context. It's useful for:
+
 - Quick testing of controller logic
 - Debugging with your IDE
 - Fast iteration without image builds
 
 **Important Notes:**
+
 - **Webhooks are disabled** - The operator runs with `ENABLE_WEBHOOKS=false`, so validation and defaulting webhooks won't be active
 - **Use `local` connection type** - When creating Workspaces in dev-host mode, use `type: local` instead of `type: in-cluster` for the connection configuration
 - Your kubeconfig must point to a running cluster (Kind, minikube, etc.)
@@ -81,7 +81,7 @@ metadata:
 spec:
   type: kubernetes
   connection:
-    type: local  # Use 'local' when running with dev-host
+    type: local # Use 'local' when running with dev-host
     secretReference:
       name: local
 ```
@@ -95,6 +95,7 @@ make dev-kind
 ```
 
 This will:
+
 1. Delete any existing `operator-dev` Kind cluster
 2. Create a fresh Kind cluster
 3. Install cert-manager
@@ -104,6 +105,7 @@ This will:
 7. Deploy the operator
 
 **Benefits of Kind Development:**
+
 - Isolated environment that won't affect other clusters
 - Tests the full deployment process
 - Validates webhook configurations
@@ -177,6 +179,7 @@ make test-e2e
 ```
 
 This will:
+
 1. Create a Kind cluster named `operator-test-e2e` (if it doesn't exist)
 2. Run e2e tests using Ginkgo
 3. Clean up the Kind cluster after tests complete
@@ -247,12 +250,14 @@ Platforms: `linux/arm64`, `linux/amd64`, `linux/s390x`, `linux/ppc64le`
 ### Debugging
 
 1. **Enable verbose logging**: Set environment variable before running:
+
    ```bash
    export LOG_LEVEL=debug
    make dev-host
    ```
 
 2. **Use delve for debugging**:
+
    ```bash
    dlv debug ./cmd/main.go
    ```

--- a/src/content/docs/guides/installation.md
+++ b/src/content/docs/guides/installation.md
@@ -2,20 +2,21 @@
 title: Installation
 description: How to install the Forkspacer operator in your Kubernetes cluster
 sidebar:
-    order: 1
+  order: 1
 ---
 
-# Installing Forkspacer
-
-This guide walks you through installing the Forkspacer operator in your Kubernetes cluster.
+This guide walks you through installing the Forkspacer operator in your Kubernetes cluster using Helm (recommended).
 
 ## Prerequisites
 
 - Kubernetes cluster (v1.20 or later)
 - `kubectl` configured to access your cluster
+- `helm` (v3.0 or later)
 - Cluster admin permissions
 
-## Installation Steps
+## Helm Installation
+
+Forkspacer is installed using Helm charts for flexible and manageable deployments.
 
 ### 1. Install cert-manager
 
@@ -33,31 +34,40 @@ kubectl wait --for=condition=available --timeout=300s deployment/cert-manager-ca
 kubectl wait --for=condition=available --timeout=300s deployment/cert-manager-webhook -n cert-manager
 ```
 
-### 2. Deploy Forkspacer
+### 2. Deploy Forkspacer with Helm
 
-Install the Forkspacer operator using Helm:
+Add the Forkspacer Helm repository:
 
 ```bash
-# Add the Forkspacer Helm repository
 helm repo add forkspacer https://forkspacer.github.io/forkspacer
 helm repo update
+```
 
-# Install Forkspacer
+<!-- Choose your installation method: -->
+
+<!-- **Option A: Operator Only (Minimal)** -->
+
+**Operator Only (Minimal)**
+
+Install just the core operator for managing workspaces and modules:
+
+```bash
 helm install forkspacer forkspacer/forkspacer \
   --namespace forkspacer-system \
   --create-namespace
 ```
 
-For advanced configuration options:
+<!-- **Option B: With Web UI and API Server**
+
+Install with the web UI and API server enabled for a complete management experience:
 
 ```bash
-# Install with custom values
 helm install forkspacer forkspacer/forkspacer \
-  --namespace forkspacer-system \
-  --create-namespace \
   --set operator-ui.enabled=true \
-  --set ingress.enabled=true
-```
+  --set api-server.enabled=true \
+  --namespace forkspacer-system \
+  --create-namespace
+``` -->
 
 ### 3. Verify Installation
 

--- a/src/content/docs/guides/quick-start.md
+++ b/src/content/docs/guides/quick-start.md
@@ -2,10 +2,8 @@
 title: Quick Start
 description: Get started with Forkspacer in 5 minutes
 sidebar:
-    order: 2
+  order: 2
 ---
-
-# Quick Start Guide
 
 This guide will help you create your first workspace and deploy a module in just a few minutes.
 
@@ -86,6 +84,26 @@ NAME    WORKSPACE   PHASE   AGE
 redis   default     ready   45s
 ```
 
+## Understanding What You Created
+
+Before we continue, let's understand what just happened:
+
+You now have three components working together:
+
+1. **Workspace** (`default`): An isolated Kubernetes environment managed by Forkspacer
+2. **Module** (`redis`): A Kubernetes CRD that declares "install Redis in the default workspace"
+3. **Module Definition**: A YAML template hosted on GitHub that describes how to install Redis using a Helm chart
+
+When you created the Module, the Forkspacer operator:
+
+1. Detected the new Module CRD
+2. Fetched the module definition from the GitHub URL
+3. Parsed the Helm configuration in that definition
+4. Installed Redis using the Helm chart specified in the definition
+5. Applied your configuration values (`replicaCount`, `version`)
+
+> **What's in that URL?** The GitHub URL points to a [module definition](/introduction/concepts/#module-definition) - a reusable template that describes how to install Redis. Module definitions can be shared across teams and stored in Git repositories. [View the Redis module definition →](https://raw.githubusercontent.com/forkspacer/modules/refs/heads/main/redis/1.0.0/module.yaml)
+
 ## Step 3: Verify the Deployment
 
 Check the pods created by the module:
@@ -155,16 +173,18 @@ kubectl delete workspace default
 ### Common Use Cases
 
 **Development Environments:**
+
 ```yaml
 # Auto-hibernate outside business hours to save costs
 spec:
   autoHibernation:
     enabled: true
-    schedule: "0 18 * * 1-5"      # 6 PM weekdays
-    wakeSchedule: "0 8 * * 1-5"   # 8 AM weekdays
+    schedule: "0 18 * * 1-5" # 6 PM weekdays
+    wakeSchedule: "0 8 * * 1-5" # 8 AM weekdays
 ```
 
 **Testing Environments:**
+
 ```yaml
 # Fork from production workspace
 spec:
@@ -175,6 +195,7 @@ spec:
 ```
 
 **Staging Environments:**
+
 ```yaml
 # Deploy from HTTP-hosted resource definitions
 spec:

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -17,20 +17,19 @@ hero:
       link: https://github.com/forkspacer/forkspacer
 ---
 
-import { Card, CardGrid } from '@astrojs/starlight/components';
+import { Card, CardGrid } from "@astrojs/starlight/components";
 
 ## Next steps
 
 <CardGrid stagger>
-	<Card title="Create a workspace" icon="pencil">
-		Create workspaces to connect local or remote Kubernetes clusters and install modules to them. You can hibernate workspaces to sleep or resume the modules installed in them.
+	<Card title="Create a Workspace" icon="pencil">
+		A Workspace is an isolated Kubernetes environment that can be hibernated and forked. Workspaces can automatically hibernate on a schedule to save costs.
 ```yaml
 apiVersion: batch.forkspacer.com/v1
 kind: Workspace
 metadata:
   name: default
   namespace: default
-
 spec:
   type: kubernetes
   connection:
@@ -40,9 +39,10 @@ spec:
     schedule: "0 42 18 * * *"
     wakeSchedule: "0 42 19 * * *"
 ```
+> **Auto-hibernation?** Workspaces can automatically sleep during off-hours (like nights and weekends) to reduce cloud costs, then wake up when needed. [Learn more →](/introduction/concepts/#workspace)
 	</Card>
-	<Card title="Install a module" icon="add-document">
-		Manage your environments via pre-defined and configurable modules.
+	<Card title="Deploy a Module" icon="add-document">
+		A Module installs an application into a workspace using a reusable module definition.
 ```yaml
 apiVersion: batch.forkspacer.com/v1
 kind: Module
@@ -59,10 +59,24 @@ spec:
     version: 21.2.7
     replicaCount: 0
 ```
+> **What's httpURL?** It points to a module definition - a reusable template that describes how to install Redis. [Learn more →](/introduction/concepts/#module-definition)
 	</Card>
-	<Card title="Module examples" icon="setting">
-	<details>
-	<summary>Helm redis example</summary>
+	<Card title="Understand Core Concepts" icon="star">
+		Learn about Workspaces, Modules, Module Definitions, and how Forkspacer manages environments with hibernation and forking.
+
+    	[Learn core concepts →](/introduction/concepts/)
+    </Card>
+    <Card title="Get Started" icon="rocket">
+    	Install Forkspacer in your cluster and create your first workspace in 5 minutes.
+
+    	[Installation guide →](/guides/installation/)
+    </Card>
+    <Card title="Module Definition Examples" icon="setting">
+    	Module definitions describe HOW to install applications. They can be Helm-based or custom containers.
+
+    	<details>
+    	<summary>Helm Module Definition Example</summary>
+
 ```yaml
 kind: Helm
 metadata:
@@ -121,22 +135,35 @@ spec:
     removeNamespace: false
     removePVCs: true
 ```
-</details>
 
-  <details>
-	<summary>Custom module example</summary>
- ```yaml
- kind: Custom
- metadata:
-   name: test
-   supportedOperatorVersion: ">= 0.0.0, < 1.0.0"
+    	</details>
 
- spec:
-   image: "my-registry/custom-module:v1.0.0"
- ```
- </details>
-	</Card>
-	<Card title="Read the docs" icon="open-book">
-		Learn more in [the Forkspacer Docs](/guides/installation/).
-	</Card>
+    	<details>
+    	<summary>Custom Module Definition Example</summary>
+
+```yaml
+kind: Custom
+metadata:
+  name: custom-installer
+  version: "1.0.0"
+  supportedOperatorVersion: ">= 0.0.0, < 1.0.0"
+  description: "Custom installation via container"
+
+config:
+  - type: string
+    name: "Environment"
+    alias: "environment"
+    spec:
+      default: "development"
+      required: true
+
+spec:
+  image: "my-registry/custom-module:v1.0.0"
+```
+
+    	</details>
+
+    	[Learn about module definitions →](/reference/resources/overview/)
+    </Card>
+
 </CardGrid>

--- a/src/content/docs/introduction/concepts.md
+++ b/src/content/docs/introduction/concepts.md
@@ -1,0 +1,440 @@
+---
+title: Core Concepts
+description: Understanding Forkspacer's key concepts and architecture
+sidebar:
+  order: 2
+---
+
+This page explains the fundamental concepts you need to understand how Forkspacer works.
+
+## The Forkspacer Model
+
+Forkspacer uses a three-layer architecture to manage environments:
+
+```
+┌─────────────────────────────────────┐
+│         Workspace (CRD)             │
+│  An isolated Kubernetes environment │
+│  • Can hibernate to save costs      │
+│  • Can be forked from others        │
+│  • Scheduled auto-hibernation       │
+└─────────────────────────────────────┘
+              ↓ contains
+┌─────────────────────────────────────┐
+│          Module (CRD)               │
+│  Declares WHAT to install           │
+│  • References a workspace           │
+│  • References a module definition   │
+│  • Provides configuration values    │
+└─────────────────────────────────────┘
+              ↓ references
+┌─────────────────────────────────────┐
+│      Module Definition              │
+│  A reusable template describing     │
+│  HOW to install an application      │
+│  • Helm: Deploy Helm charts         │
+│  • Custom: Run install containers   │
+└─────────────────────────────────────┘
+```
+
+**Think of it like this:**
+
+- **Workspace** = A separate development environment (like a VM or namespace, but smarter)
+- **Module** = A declaration "Install Redis in my-workspace with these settings"
+- **Module Definition** = The actual instructions for installing Redis
+
+## Workspace
+
+A **Workspace** represents an isolated Kubernetes environment that Forkspacer can manage. It's a Kubernetes Custom Resource (CRD) that describes an environment.
+
+### Key Capabilities
+
+**Hibernation**: Scale down all workloads to save resources and costs
+
+```yaml
+spec:
+  hibernated: true
+```
+
+**Auto-hibernation**: Schedule automatic sleep/wake cycles
+
+```yaml
+spec:
+  autoHibernation:
+    enabled: true
+    schedule: "0 18 * * 1-5" # Sleep at 6 PM weekdays
+    wakeSchedule: "0 8 * * 1-5" # Wake at 8 AM weekdays
+```
+
+**Forking**: Clone an entire workspace including all its modules
+
+```yaml
+spec:
+  from:
+    name: production-workspace
+    namespace: prod
+    migrateData: true # Optional: copy persistent data
+```
+
+### Connection Types
+
+Workspaces can target different Kubernetes clusters:
+
+- **`in-cluster`**: The same cluster where Forkspacer runs
+- **`local`**: Uses your local kubeconfig (development mode)
+- **`kubeconfig`**: Uses a kubeconfig stored in a Secret (remote clusters)
+
+### Use Cases
+
+- **Development environments** that automatically hibernate after hours
+- **Testing environments** forked from staging with real data
+- **Preview environments** for feature branches that clean up automatically
+- **Cost optimization** for non-production workloads
+
+## Module
+
+A **Module** is a Kubernetes CRD that declares **what** application to install into a workspace and **how** to configure it.
+
+### Anatomy of a Module
+
+```yaml
+apiVersion: batch.forkspacer.com/v1
+kind: Module
+metadata:
+  name: redis # Name of this module instance
+spec:
+  workspace: # Where to install
+    name: dev-environment
+  source: # Where to get installation instructions
+    httpURL: https://example.com/modules/redis.yaml
+  config: # Configuration values
+    replicaCount: 2
+    version: "21.2.9"
+```
+
+### What Modules Do
+
+1. **Reference a workspace**: Specifies which environment to target
+2. **Reference a module definition**: Points to installation instructions (via URL, ConfigMap, or raw YAML)
+3. **Provide configuration**: Pass values that customize the installation
+4. **Track status**: Report installation state (installing, ready, failed, etc.)
+
+### Module Sources
+
+Modules can load their definitions from multiple sources:
+
+**HTTP URL** (most common):
+
+```yaml
+source:
+  httpURL: https://raw.githubusercontent.com/forkspacer/modules/main/redis/module.yaml
+```
+
+**Raw embedded**:
+
+```yaml
+source:
+  raw:
+    kind: Helm
+    metadata:
+      name: redis
+    spec:
+      repo: https://charts.bitnami.com/bitnami
+      chartName: redis
+```
+
+**ConfigMap**:
+
+```yaml
+source:
+  configMap:
+    name: redis-module-definition
+```
+
+**Existing Helm release** (adopt already-installed apps):
+
+```yaml
+source:
+  existingHelmRelease:
+    name: existing-redis
+    namespace: default
+```
+
+## Module Definition
+
+A **Module Definition** is a reusable template that describes **how** to install an application. Think of it as a recipe that Modules follow.
+
+Module Definitions are **not** Kubernetes resources. They are YAML files that define installation logic.
+
+### Two Types
+
+#### Helm Module Definitions
+
+Deploy Helm charts with configurable values:
+
+```yaml
+kind: Helm
+metadata:
+  name: redis
+  version: "1.0.0"
+  supportedOperatorVersion: ">= 0.0.0, < 1.0.0"
+
+config:
+  - type: integer
+    name: "Replica Count"
+    alias: replicaCount
+    spec:
+      default: 1
+      min: 0
+      max: 5
+
+spec:
+  namespace: default
+  repo: https://charts.bitnami.com/bitnami
+  chartName: redis
+  version: "21.2.9"
+  values:
+    - raw:
+        replica:
+          replicaCount: "{{.config.replicaCount}}"
+```
+
+#### Custom Module Definitions
+
+Run containerized installation logic (any language):
+
+```yaml
+kind: Custom
+metadata:
+  name: complex-installer
+  version: "1.0.0"
+  supportedOperatorVersion: ">= 0.0.0, < 1.0.0"
+
+spec:
+  image: "my-registry/installer:v1.0.0"
+```
+
+The container receives HTTP requests to install, uninstall, hibernate, and resume applications.
+
+### Configuration Schema
+
+Module Definitions declare what configuration options they accept:
+
+```yaml
+config:
+  - type: option # Dropdown selection
+    name: "Environment"
+    alias: environment
+    spec:
+      values: [dev, staging, prod]
+      default: "dev"
+
+  - type: integer # Number with validation
+    name: "Replicas"
+    alias: replicas
+    spec:
+      min: 1
+      max: 10
+      default: 3
+
+  - type: string # Text with regex validation
+    name: "Domain"
+    alias: domain
+    spec:
+      regex: "^[a-z0-9.-]+$"
+```
+
+Users provide values when creating Modules:
+
+```yaml
+# Module references the definition and provides config
+spec:
+  source:
+    httpURL: https://example.com/modules/myapp.yaml
+  config:
+    environment: staging
+    replicas: 5
+    domain: "staging.example.com"
+```
+
+The operator validates config against the schema before installation.
+
+## Hibernation
+
+**Hibernation** is Forkspacer's cost-saving feature that scales down resources while preserving state.
+
+### How It Works
+
+When a Workspace hibernates:
+
+1. All Modules in the workspace are instructed to hibernate
+2. For Helm modules: Deployments/StatefulSets scale to 0 replicas
+3. For Custom modules: The container receives a hibernate HTTP request
+4. State is preserved (ConfigMaps, Secrets, PVCs remain)
+
+When a Workspace wakes:
+
+1. Resources scale back to original replica counts
+2. Applications resume normal operation
+
+### Manual Hibernation
+
+```yaml
+# Hibernate immediately
+kubectl patch workspace dev -p '{"spec":{"hibernated":true}}' --type=merge
+
+# Wake up
+kubectl patch workspace dev -p '{"spec":{"hibernated":false}}' --type=merge
+```
+
+### Automatic Hibernation
+
+Schedule hibernation with cron expressions:
+
+```yaml
+spec:
+  autoHibernation:
+    enabled: true
+    schedule: "0 18 * * 1-5" # 6 PM weekdays
+    wakeSchedule: "0 8 * * 1-5" # 8 AM weekdays
+```
+
+**Cron format**: `minute hour day month weekday` (5 fields) or `second minute hour day month weekday` (6 fields)
+
+### Module-Level Hibernation
+
+Individual modules can hibernate independently:
+
+```yaml
+apiVersion: batch.forkspacer.com/v1
+kind: Module
+metadata:
+  name: expensive-service
+spec:
+  hibernated: true # Only this module hibernates
+```
+
+## Forking
+
+**Forking** creates a complete copy of a workspace, including all its modules.
+
+### Basic Forking
+
+```yaml
+apiVersion: batch.forkspacer.com/v1
+kind: Workspace
+metadata:
+  name: testing-env
+spec:
+  from:
+    name: staging-env
+    namespace: staging
+```
+
+This creates:
+
+- A new workspace named `testing-env`
+- Copies of all Modules from `staging-env`
+- Fresh installations with the same configuration
+
+### Forking with Data Migration
+
+```yaml
+spec:
+  from:
+    name: production
+    namespace: prod
+    migrateData: true
+```
+
+With `migrateData: true`, Forkspacer also copies:
+
+- Persistent Volume Claims (PVCs)
+- Secrets
+- ConfigMaps
+
+**Important**: Data migration:
+
+- Temporarily hibernates source and destination during transfer
+- Requires module definitions to specify migration configuration
+- Is not guaranteed (depends on storage compatibility)
+- Preserves the source workspace unchanged
+
+### Use Cases
+
+- **Testing with production data**: Fork prod to staging with real data
+- **Feature development**: Each developer forks from a baseline
+- **Debugging**: Fork production to investigate issues without affecting users
+- **Training environments**: Create disposable environments from templates
+
+## Putting It Together
+
+Here's a complete example showing how these concepts work together:
+
+```yaml
+# 1. Create a workspace that hibernates after hours
+apiVersion: batch.forkspacer.com/v1
+kind: Workspace
+metadata:
+  name: dev-environment
+  namespace: default
+spec:
+  type: kubernetes
+  connection:
+    type: in-cluster
+  autoHibernation:
+    enabled: true
+    schedule: "0 18 * * 1-5"
+    wakeSchedule: "0 8 * * 1-5"
+
+---
+# 2. Deploy Redis module into the workspace
+apiVersion: batch.forkspacer.com/v1
+kind: Module
+metadata:
+  name: redis
+  namespace: default
+spec:
+  workspace:
+    name: dev-environment
+  source:
+    httpURL: https://raw.githubusercontent.com/forkspacer/modules/main/redis/1.0.0/module.yaml
+  config:
+    replicaCount: 2
+    version: "21.2.9"
+
+---
+# 3. Deploy PostgreSQL module into the same workspace
+apiVersion: batch.forkspacer.com/v1
+kind: Module
+metadata:
+  name: postgres
+  namespace: default
+spec:
+  workspace:
+    name: dev-environment
+  source:
+    httpURL: https://raw.githubusercontent.com/forkspacer/modules/main/postgresql/1.0.0/module.yaml
+  config:
+    storageSize: "10Gi"
+    enableBackups: false
+```
+
+**What happens**:
+
+1. Forkspacer creates the `dev-environment` workspace
+2. Fetches the Redis module definition from GitHub
+3. Installs Redis using the Helm chart specified in the definition
+4. Fetches the PostgreSQL module definition
+5. Installs PostgreSQL
+6. At 6 PM on weekdays, automatically hibernates both Redis and PostgreSQL
+7. At 8 AM on weekdays, automatically wakes them back up
+
+## Next Steps
+
+Now that you understand the core concepts:
+
+- **[Install Forkspacer →](/guides/installation/)** - Set up the operator in your cluster
+- **[Quick Start →](/guides/quick-start/)** - Create your first workspace and module
+- **[CRD Reference →](/reference/crds/overview/)** - Detailed API documentation
+- **[Module Definitions →](/reference/resources/overview/)** - Learn to create reusable module definitions

--- a/src/content/docs/introduction/overview.md
+++ b/src/content/docs/introduction/overview.md
@@ -1,0 +1,286 @@
+---
+title: What is Forkspacer?
+description: Introduction to Forkspacer and how it helps manage ephemeral Kubernetes environments
+sidebar:
+  order: 1
+---
+
+Forkspacer is an open-source Kubernetes operator that lets you create, fork, and hibernate entire development environments. It's designed for teams where each developer or feature branch needs an isolated, reproducible environment that can be managed declaratively.
+
+## The Problem
+
+Modern development teams face challenges managing multiple environments:
+
+**Cost Explosion**: Running 10 developer environments 24/7 wastes resources during nights and weekends. Traditional solutions require manual intervention or complex scripts to scale down workloads.
+
+**Environment Drift**: Manually created environments diverge from production. "It works on my machine" becomes "it works in my namespace" when each developer configures their environment differently.
+
+**Slow Provisioning**: Creating a new testing environment requires copying Helm commands, updating values, managing secrets, and configuring services. This can take hours or days.
+
+**Data Isolation Challenges**: Testing with production-like data requires either sharing a database (risking conflicts) or complex data migration scripts.
+
+## The Solution
+
+Forkspacer treats entire environments as declarative, forkable, hibernate-able resources.
+
+### Declarative Environments
+
+Define environments in YAML with GitOps-style reproducibility:
+
+```yaml
+apiVersion: batch.forkspacer.com/v1
+kind: Workspace
+metadata:
+  name: feature-auth
+spec:
+  type: kubernetes
+  autoHibernation:
+    enabled: true
+    schedule: "0 18 * * 1-5" # Sleep after work hours
+```
+
+### Environment Forking
+
+Clone entire environments, including all applications and optionally their data:
+
+```yaml
+spec:
+  from:
+    name: staging
+    namespace: staging
+    migrateData: true # Copy persistent data too
+```
+
+This creates a complete copy with all databases, services, and configuration.
+
+### Automatic Hibernation
+
+Save costs by automatically scaling down idle environments:
+
+- **Scheduled**: Cron-based wake/sleep cycles
+- **Manual**: Instant hibernation on-demand
+- **Per-module**: Hibernate expensive services independently
+
+### Reusable Module Definitions
+
+Install applications using pre-defined, configurable templates:
+
+```yaml
+apiVersion: batch.forkspacer.com/v1
+kind: Module
+metadata:
+  name: postgres
+spec:
+  workspace:
+    name: feature-auth
+  source:
+    httpURL: https://modules.forkspacer.com/postgresql.yaml
+  config:
+    storageSize: "20Gi"
+    replicas: 2
+```
+
+The module definition handles all Helm chart complexity, exposing only relevant configuration.
+
+## Key Benefits
+
+### Cost Optimization
+
+- **Automatic hibernation** reduces compute costs by 70-80% for non-production environments
+- **Scheduled wake/sleep** ensures environments only run during business hours
+- **Selective hibernation** allows hibernating expensive components (databases, ML models) independently
+
+### Developer Productivity
+
+- **Instant environment creation** via `kubectl apply` instead of manual setup
+- **Fork from production** to debug with real data in isolated environments
+- **Self-service** without waiting for DevOps intervention
+- **Consistent environments** eliminate "works on my machine" issues
+
+### GitOps Integration
+
+- **Declarative configuration** fits naturally into GitOps workflows
+- **Version controlled environments** track changes over time
+- **Reproducible deployments** from any point in history
+- **PR-based workflows** for environment changes
+
+### Flexibility
+
+- **Helm chart support** for standard applications
+- **Custom modules** for complex installation logic
+- **Multi-cluster** support for testing in different regions
+- **Adopt existing resources** to manage already-deployed applications
+
+## Use Cases
+
+### Development Environments
+
+**Problem**: 15 developers each need Redis, PostgreSQL, and a message queue. Running 24/7 wastes resources.
+
+**Solution**: Each developer has a workspace that:
+
+- Forks from a "baseline" template
+- Auto-hibernates evenings and weekends (70% cost reduction)
+- Can be recreated from scratch in minutes
+
+```yaml
+# developer-baseline workspace
+# Each dev forks this and adds their custom services
+apiVersion: batch.forkspacer.com/v1
+kind: Workspace
+metadata:
+  name: dev-alice
+spec:
+  from:
+    name: baseline
+  autoHibernation:
+    enabled: true
+    schedule: "0 18 * * 1-5"
+```
+
+### Testing Environments
+
+**Problem**: QA needs to test with production-like data but can't risk affecting real users.
+
+**Solution**: Fork production workspace to staging with data migration:
+
+```yaml
+apiVersion: batch.forkspacer.com/v1
+kind: Workspace
+metadata:
+  name: qa-testing-sprint-23
+spec:
+  from:
+    name: production
+    namespace: prod
+    migrateData: true # Copy all PVCs, Secrets, ConfigMaps
+```
+
+Test freely in isolation, then delete when done.
+
+### Preview Environments
+
+**Problem**: Creating a preview environment for each PR is manual and tedious.
+
+**Solution**: CI pipeline creates a workspace per PR, automatically hibernates when inactive, and deletes on merge:
+
+```yaml
+apiVersion: batch.forkspacer.com/v1
+kind: Workspace
+metadata:
+  name: pr-1234
+  labels:
+    pr-number: "1234"
+spec:
+  from:
+    name: staging
+  autoHibernation:
+    enabled: true
+    schedule: "0 0 * * *" # Hibernate daily at midnight
+```
+
+### Staging Environments
+
+**Problem**: Staging runs 24/7 but is only used during business hours.
+
+**Solution**: Auto-hibernate staging on nights and weekends:
+
+```yaml
+spec:
+  autoHibernation:
+    enabled: true
+    schedule: "0 18 * * 1-5" # Sleep 6 PM weekdays
+    wakeSchedule: "0 8 * * 1-5" # Wake 8 AM weekdays
+```
+
+## How It's Different
+
+### vs. Namespace-per-Developer
+
+**Traditional approach**: Each developer gets a namespace and manually installs services.
+
+**Problems**:
+
+- No hibernation support
+- No environment forking
+- Manual installation is error-prone
+- Resources waste money when idle
+
+**Forkspacer**: Treats the entire namespace as a managed entity with lifecycle automation.
+
+### vs. Ephemeral Environments (Okteto, DevSpace)
+
+**Similar tools** focus on syncing local code to remote clusters for development.
+
+**Forkspacer** focuses on managing complete, long-lived environments (dev, staging, testing) with:
+
+- Hibernation for cost savings
+- Environment forking for data isolation
+- Multi-workspace orchestration
+- Production-ready operator design
+
+### vs. Manual Helm/Kubectl
+
+**Traditional approach**: Run Helm commands manually or via scripts.
+
+**Forkspacer**:
+
+- Declarative workspace definitions
+- Reusable module templates
+- Built-in hibernation and forking
+- Operator-managed reconciliation
+
+### vs. Terraform/Pulumi
+
+**IaC tools** provision infrastructure but don't provide:
+
+- Application-level hibernation
+- Environment forking with data
+- Kubernetes-native CRDs
+- Real-time reconciliation
+
+**Forkspacer** works alongside IaC tools, managing application-level environment lifecycle.
+
+## Architecture
+
+Forkspacer is a Kubernetes operator built with:
+
+- **Custom Resource Definitions (CRDs)**: Workspace and Module
+- **Controller Pattern**: Reconciles desired state continuously
+- **Helm Integration**: Deploys charts with templated values
+- **Extensibility**: Custom modules via containerized HTTP services
+
+It runs entirely within Kubernetes and requires no external dependencies beyond cert-manager.
+
+## When to Use Forkspacer
+
+**Good fit** when you:
+
+- Need multiple isolated environments (dev, staging, testing, preview)
+- Want to reduce cloud costs for non-production workloads
+- Need to fork environments with or without data
+- Want GitOps-style declarative environment management
+- Use Kubernetes and Helm
+
+**Not a good fit** when you:
+
+- Only need a single production environment
+- Don't use Kubernetes
+- Need sub-second environment creation (forking takes minutes)
+- Require Windows container support
+
+## Getting Started
+
+Ready to try Forkspacer?
+
+1. **[Understand Core Concepts →](/introduction/concepts/)** - Learn about Workspaces, Modules, and Hibernation
+2. **[Install Forkspacer →](/guides/installation/)** - Deploy the operator to your cluster
+3. **[Quick Start →](/guides/quick-start/)** - Create your first workspace in 5 minutes
+
+## Community
+
+- **GitHub**: [github.com/forkspacer/forkspacer](https://github.com/forkspacer/forkspacer)
+- **Documentation**: You're reading it!
+- **Issues**: [Report bugs or request features](https://github.com/forkspacer/forkspacer/issues)
+
+Forkspacer is open-source under the Apache 2.0 license.

--- a/src/content/docs/reference/CRDs/module.md
+++ b/src/content/docs/reference/CRDs/module.md
@@ -2,10 +2,8 @@
 title: Module
 description: Module Custom Resource Definition reference
 sidebar:
-    order: 3
+  order: 3
 ---
-
-# Module
 
 The `Module` resource represents an installable component or application that can be deployed into a `Workspace`. Modules reference resource definitions (Helm charts or custom modules) and support hibernation to reduce resource consumption.
 
@@ -65,27 +63,28 @@ spec:
 
 The `.spec` field defines the desired state of the Module.
 
-| Field | Type | Description | Required |
-|-------|------|-------------|----------|
-| `source` | object | Source location of the module manifests. See [Source](#source). | Yes |
-| `workspace` | object | Reference to the workspace where this module should be deployed. See [WorkspaceReference](#workspacereference). | Yes |
-| `config` | object | Custom configuration for the module (arbitrary key-value pairs). | No |
-| `hibernated` | boolean | Whether the module should be in hibernated state. | No (default: `false`) |
+| Field        | Type    | Description                                                                                                     | Required              |
+| ------------ | ------- | --------------------------------------------------------------------------------------------------------------- | --------------------- |
+| `source`     | object  | Source location of the module manifests. See [Source](#source).                                                 | Yes                   |
+| `workspace`  | object  | Reference to the workspace where this module should be deployed. See [WorkspaceReference](#workspacereference). | Yes                   |
+| `config`     | object  | Custom configuration for the module (arbitrary key-value pairs).                                                | No                    |
+| `hibernated` | boolean | Whether the module should be in hibernated state.                                                               | No (default: `false`) |
 
 ### Source
 
 The `source` field specifies where the resource definition should be loaded from. Resource definitions describe either Helm charts or custom modules with their configuration schemas. Only one source type should be specified.
 
-| Field | Type | Description | Required |
-|-------|------|-------------|----------|
-| `raw` | object | Raw resource definition embedded directly in the Module resource. | No |
-| `configMap` | object | Reference to a ConfigMap containing the resource definition. See [ConfigMapSource](#configmapsource). | No |
-| `httpURL` | string | HTTP/HTTPS URL pointing to a resource definition YAML file. | No |
-| `existingHelmRelease` | object | Reference to an existing Helm release to adopt and track. See [ExistingHelmReleaseSource](#existinghelmreleasesource). | No |
+| Field                 | Type   | Description                                                                                                            | Required |
+| --------------------- | ------ | ---------------------------------------------------------------------------------------------------------------------- | -------- |
+| `raw`                 | object | Raw resource definition embedded directly in the Module resource.                                                      | No       |
+| `configMap`           | object | Reference to a ConfigMap containing the resource definition. See [ConfigMapSource](#configmapsource).                  | No       |
+| `httpURL`             | string | HTTP/HTTPS URL pointing to a resource definition YAML file.                                                            | No       |
+| `existingHelmRelease` | object | Reference to an existing Helm release to adopt and track. See [ExistingHelmReleaseSource](#existinghelmreleasesource). | No       |
 
 **Resource Definition Types:**
 
 The source must point to or contain a resource definition with one of these kinds:
+
 - **`Helm`**: Deploys a Helm chart - [Learn more →](/reference/resources/helm/)
 - **`Custom`**: Runs a custom containerized module - [Learn more →](/reference/resources/custom/)
 
@@ -141,9 +140,9 @@ spec:
 
 The `configMap` source type references a Kubernetes ConfigMap that contains the resource definition.
 
-| Field | Type | Description | Required |
-|-------|------|-------------|----------|
-| `name` | string | Name of the ConfigMap. | Yes |
+| Field       | Type   | Description                 | Required                            |
+| ----------- | ------ | --------------------------- | ----------------------------------- |
+| `name`      | string | Name of the ConfigMap.      | Yes                                 |
 | `namespace` | string | Namespace of the ConfigMap. | No (defaults to Module's namespace) |
 
 The ConfigMap must contain a key named `module.yaml` with the resource definition as its value:
@@ -172,9 +171,9 @@ data:
 
 The `existingHelmRelease` source type allows you to adopt and track existing Helm releases without reinstalling them. This is useful when you have pre-existing Helm releases in your cluster and want to manage them through Forkspacer without disruption.
 
-| Field | Type | Description | Required |
-|-------|------|-------------|----------|
-| `name` | string | Name of the existing Helm release. | Yes |
+| Field       | Type   | Description                                    | Required                   |
+| ----------- | ------ | ---------------------------------------------- | -------------------------- |
+| `name`      | string | Name of the existing Helm release.             | Yes                        |
 | `namespace` | string | Namespace where the Helm release is installed. | No (defaults to `default`) |
 
 **Important:** When a Module with an adopted Helm release is deleted, the underlying Helm release is **not** uninstalled. The Module only detaches from the release, leaving it running in the cluster.
@@ -183,9 +182,9 @@ The `existingHelmRelease` source type allows you to adopt and track existing Hel
 
 The `workspace` field references the target workspace where the module will be deployed.
 
-| Field | Type | Description | Required |
-|-------|------|-------------|----------|
-| `name` | string | Name of the target workspace. | Yes |
+| Field       | Type   | Description                        | Required                |
+| ----------- | ------ | ---------------------------------- | ----------------------- |
+| `name`      | string | Name of the target workspace.      | Yes                     |
 | `namespace` | string | Namespace of the target workspace. | No (default: `default`) |
 
 **Example:**
@@ -217,12 +216,12 @@ spec:
 
 The `.status` field reflects the observed state of the Module.
 
-| Field | Type | Description | Required |
-|-------|------|-------------|----------|
-| `phase` | string | Current phase of the module. Values: `ready`, `installing`, `uninstalling`, `sleeping`, `sleeped`, `resuming`, `failed`. | Yes |
-| `lastActivity` | string (date-time) | Timestamp of the last activity for this module. | No |
-| `message` | string | Human-readable message about the current state. | No |
-| `conditions` | array | Standard Kubernetes conditions. See [Conditions](#conditions). | No |
+| Field          | Type               | Description                                                                                                              | Required |
+| -------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------ | -------- |
+| `phase`        | string             | Current phase of the module. Values: `ready`, `installing`, `uninstalling`, `sleeping`, `sleeped`, `resuming`, `failed`. | Yes      |
+| `lastActivity` | string (date-time) | Timestamp of the last activity for this module.                                                                          | No       |
+| `message`      | string             | Human-readable message about the current state.                                                                          | No       |
+| `conditions`   | array              | Standard Kubernetes conditions. See [Conditions](#conditions).                                                           | No       |
 
 ### Conditions
 
@@ -234,14 +233,14 @@ Standard Kubernetes condition types used to represent the module state:
 
 Each condition has the following fields:
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `type` | string | Condition type (e.g., "Available", "Progressing", "Degraded"). |
-| `status` | string | Condition status: `True`, `False`, or `Unknown`. |
-| `lastTransitionTime` | string (date-time) | Last time the condition transitioned. |
-| `reason` | string | Programmatic identifier for the condition's last transition. |
-| `message` | string | Human-readable message explaining the condition. |
-| `observedGeneration` | integer | The `.metadata.generation` that the condition was set based upon. |
+| Field                | Type               | Description                                                       |
+| -------------------- | ------------------ | ----------------------------------------------------------------- |
+| `type`               | string             | Condition type (e.g., "Available", "Progressing", "Degraded").    |
+| `status`             | string             | Condition status: `True`, `False`, or `Unknown`.                  |
+| `lastTransitionTime` | string (date-time) | Last time the condition transitioned.                             |
+| `reason`             | string             | Programmatic identifier for the condition's last transition.      |
+| `message`            | string             | Human-readable message explaining the condition.                  |
+| `observedGeneration` | integer            | The `.metadata.generation` that the condition was set based upon. |
 
 ## Phase Values
 

--- a/src/content/docs/reference/CRDs/workspace.md
+++ b/src/content/docs/reference/CRDs/workspace.md
@@ -2,10 +2,8 @@
 title: Workspace
 description: Workspace Custom Resource Definition reference
 sidebar:
-    order: 2
+  order: 2
 ---
-
-# Workspace
 
 The `Workspace` resource represents a Kubernetes environment that can be managed, hibernated, and forked by the forkspacer operator. It provides capabilities for environment lifecycle management, including automatic hibernation scheduling and connection configuration.
 
@@ -35,23 +33,23 @@ spec:
 
 The `.spec` field defines the desired state of the Workspace.
 
-| Field | Type | Description | Required |
-|-------|------|-------------|----------|
-| `type` | string | Type of workspace. Currently only supports `kubernetes`. | No (default: `kubernetes`) |
-| `from` | object | Reference to another workspace to fork from. See [FromReference](#fromreference). | No |
-| `hibernated` | boolean | Whether the workspace should be in hibernated state. | No (default: `false`) |
-| `connection` | object | Configuration for connecting to the workspace. See [Connection](#connection). | No |
-| `autoHibernation` | object | Configuration for automatic hibernation scheduling. See [AutoHibernation](#autohibernation). | No |
+| Field             | Type    | Description                                                                                  | Required                   |
+| ----------------- | ------- | -------------------------------------------------------------------------------------------- | -------------------------- |
+| `type`            | string  | Type of workspace. Currently only supports `kubernetes`.                                     | No (default: `kubernetes`) |
+| `from`            | object  | Reference to another workspace to fork from. See [FromReference](#fromreference).            | No                         |
+| `hibernated`      | boolean | Whether the workspace should be in hibernated state.                                         | No (default: `false`)      |
+| `connection`      | object  | Configuration for connecting to the workspace. See [Connection](#connection).                | No                         |
+| `autoHibernation` | object  | Configuration for automatic hibernation scheduling. See [AutoHibernation](#autohibernation). | No                         |
 
 ### FromReference
 
 The `from` field allows you to create a workspace by forking from an existing workspace. Forking creates a new workspace with copies of all modules from the source workspace. Optionally, you can migrate persistent data from the source workspace to the new workspace.
 
-| Field | Type | Description | Required |
-|-------|------|-------------|----------|
-| `name` | string | Name of the source workspace to fork from. | Yes |
-| `namespace` | string | Namespace of the source workspace. | Yes (default: `default`) |
-| `migrateData` | boolean | Whether to migrate persistent data (PVCs, Secrets, ConfigMaps) from source workspace modules to the new workspace. | No (default: `false`) |
+| Field         | Type    | Description                                                                                                        | Required                 |
+| ------------- | ------- | ------------------------------------------------------------------------------------------------------------------ | ------------------------ |
+| `name`        | string  | Name of the source workspace to fork from.                                                                         | Yes                      |
+| `namespace`   | string  | Namespace of the source workspace.                                                                                 | Yes (default: `default`) |
+| `migrateData` | boolean | Whether to migrate persistent data (PVCs, Secrets, ConfigMaps) from source workspace modules to the new workspace. | No (default: `false`)    |
 
 **Note:** Data migration is not 100% guaranteed and depends on factors such as storage class compatibility, cluster connectivity, and resource accessibility.
 
@@ -78,10 +76,10 @@ spec:
 
 The `connection` field configures how the operator connects to the workspace.
 
-| Field | Type | Description | Required |
-|-------|------|-------------|----------|
-| `type` | string | Connection type. Options: `local`, `in-cluster`, `kubeconfig`. | Yes (default: `local`) |
-| `secretReference` | object | Reference to a secret containing connection credentials. See [SecretReference](#secretreference). | No |
+| Field             | Type   | Description                                                                                       | Required               |
+| ----------------- | ------ | ------------------------------------------------------------------------------------------------- | ---------------------- |
+| `type`            | string | Connection type. Options: `local`, `in-cluster`, `kubeconfig`.                                    | Yes (default: `local`) |
+| `secretReference` | object | Reference to a secret containing connection credentials. See [SecretReference](#secretreference). | No                     |
 
 **Example:**
 
@@ -98,24 +96,25 @@ spec:
 
 The `secretReference` field within `connection` specifies a Kubernetes Secret containing connection credentials.
 
-| Field | Type | Description | Required |
-|-------|------|-------------|----------|
-| `name` | string | Name of the secret. | Yes |
+| Field       | Type   | Description              | Required                |
+| ----------- | ------ | ------------------------ | ----------------------- |
+| `name`      | string | Name of the secret.      | Yes                     |
 | `namespace` | string | Namespace of the secret. | No (default: `default`) |
 
 ### AutoHibernation
 
 The `autoHibernation` field enables automatic hibernation and wake scheduling based on cron expressions.
 
-| Field | Type | Description | Required |
-|-------|------|-------------|----------|
-| `enabled` | boolean | Whether auto-hibernation is enabled. | No (default: `false`) |
-| `schedule` | string | Cron expression for hibernation schedule. Supports standard 5-field format or 6-field format with optional seconds. | Yes (when enabled) |
-| `wakeSchedule` | string | Cron expression for wake schedule. Supports standard 5-field format or 6-field format with optional seconds. | No |
+| Field          | Type    | Description                                                                                                         | Required              |
+| -------------- | ------- | ------------------------------------------------------------------------------------------------------------------- | --------------------- |
+| `enabled`      | boolean | Whether auto-hibernation is enabled.                                                                                | No (default: `false`) |
+| `schedule`     | string  | Cron expression for hibernation schedule. Supports standard 5-field format or 6-field format with optional seconds. | Yes (when enabled)    |
+| `wakeSchedule` | string  | Cron expression for wake schedule. Supports standard 5-field format or 6-field format with optional seconds.        | No                    |
 
 **Cron Format:**
 
 The cron expressions support two formats:
+
 - **5-field format**: `minute hour day month weekday` (e.g., `0 22 * * *`)
 - **6-field format**: `second minute hour day month weekday` (e.g., `0 0 22 * * *`)
 
@@ -125,22 +124,22 @@ The cron expressions support two formats:
 spec:
   autoHibernation:
     enabled: true
-    schedule: "0 22 * * *"        # 5-field: Hibernate at 10 PM daily
-    wakeSchedule: "0 0 6 * * *"   # 6-field: Wake at 6 AM daily (with seconds)
+    schedule: "0 22 * * *" # 5-field: Hibernate at 10 PM daily
+    wakeSchedule: "0 0 6 * * *" # 6-field: Wake at 6 AM daily (with seconds)
 ```
 
 ## Status Fields
 
 The `.status` field reflects the observed state of the Workspace.
 
-| Field | Type | Description | Required |
-|-------|------|-------------|----------|
-| `phase` | string | Current phase of the workspace. Values: `ready`, `hibernated`, `failed`, `terminating`. | Yes |
-| `ready` | boolean | Indicates if the workspace is fully operational. | No (default: `false`) |
-| `lastActivity` | string (date-time) | Timestamp of the last activity in the workspace. | No |
-| `hibernatedAt` | string (date-time) | Timestamp when the workspace was hibernated. | No |
-| `message` | string | Human-readable message about the current state. | No |
-| `conditions` | array | Standard Kubernetes conditions. See [Conditions](#conditions). | No |
+| Field          | Type               | Description                                                                             | Required              |
+| -------------- | ------------------ | --------------------------------------------------------------------------------------- | --------------------- |
+| `phase`        | string             | Current phase of the workspace. Values: `ready`, `hibernated`, `failed`, `terminating`. | Yes                   |
+| `ready`        | boolean            | Indicates if the workspace is fully operational.                                        | No (default: `false`) |
+| `lastActivity` | string (date-time) | Timestamp of the last activity in the workspace.                                        | No                    |
+| `hibernatedAt` | string (date-time) | Timestamp when the workspace was hibernated.                                            | No                    |
+| `message`      | string             | Human-readable message about the current state.                                         | No                    |
+| `conditions`   | array              | Standard Kubernetes conditions. See [Conditions](#conditions).                          | No                    |
 
 ### Conditions
 
@@ -152,14 +151,14 @@ Standard Kubernetes condition types used to represent the workspace state:
 
 Each condition has the following fields:
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `type` | string | Condition type (e.g., "Available", "Progressing", "Degraded"). |
-| `status` | string | Condition status: `True`, `False`, or `Unknown`. |
-| `lastTransitionTime` | string (date-time) | Last time the condition transitioned. |
-| `reason` | string | Programmatic identifier for the condition's last transition. |
-| `message` | string | Human-readable message explaining the condition. |
-| `observedGeneration` | integer | The `.metadata.generation` that the condition was set based upon. |
+| Field                | Type               | Description                                                       |
+| -------------------- | ------------------ | ----------------------------------------------------------------- |
+| `type`               | string             | Condition type (e.g., "Available", "Progressing", "Degraded").    |
+| `status`             | string             | Condition status: `True`, `False`, or `Unknown`.                  |
+| `lastTransitionTime` | string (date-time) | Last time the condition transitioned.                             |
+| `reason`             | string             | Programmatic identifier for the condition's last transition.      |
+| `message`            | string             | Human-readable message explaining the condition.                  |
+| `observedGeneration` | integer            | The `.metadata.generation` that the condition was set based upon. |
 
 ## Phase Values
 
@@ -193,8 +192,8 @@ metadata:
 spec:
   autoHibernation:
     enabled: true
-    schedule: "0 18 * * 1-5"  # Hibernate on weekday evenings
-    wakeSchedule: "0 8 * * 1-5"  # Wake on weekday mornings
+    schedule: "0 18 * * 1-5" # Hibernate on weekday evenings
+    wakeSchedule: "0 8 * * 1-5" # Wake on weekday mornings
 ```
 
 ### Forking from Another Workspace

--- a/src/content/docs/reference/Resources/custom.md
+++ b/src/content/docs/reference/Resources/custom.md
@@ -2,10 +2,8 @@
 title: Custom
 description: Custom resource definition reference for container-based modules
 sidebar:
-    order: 3
+  order: 3
 ---
-
-# Custom Resources
 
 Custom resources define Docker container-based modules that can be executed within a Module. They provide a flexible way to run custom installation, configuration, and management logic using containerized HTTP services that integrate with the operator.
 
@@ -41,17 +39,17 @@ spec:
 
 ## Metadata Fields
 
-| Field | Type | Description | Required |
-|-------|------|-------------|----------|
-| `name` | string | Unique identifier for the resource | Yes |
-| `version` | string | Semantic version of the resource definition | Yes |
-| `supportedOperatorVersion` | string | Operator version constraint (semver format, e.g., ">= 0.0.0, < 1.0.0") | Yes |
-| `author` | string | Resource author or maintainer | No |
-| `description` | string | Human-readable description of the resource | No |
-| `category` | string | Resource category for organization | No |
-| `image` | string | URL to an icon or logo image | No |
-| `resource_usage.cpu` | string | Expected CPU usage (e.g., "500m", "2") | No |
-| `resource_usage.memory` | string | Expected memory usage (e.g., "512Mi", "2Gi") | No |
+| Field                      | Type   | Description                                                            | Required |
+| -------------------------- | ------ | ---------------------------------------------------------------------- | -------- |
+| `name`                     | string | Unique identifier for the resource                                     | Yes      |
+| `version`                  | string | Semantic version of the resource definition                            | Yes      |
+| `supportedOperatorVersion` | string | Operator version constraint (semver format, e.g., ">= 0.0.0, < 1.0.0") | Yes      |
+| `author`                   | string | Resource author or maintainer                                          | No       |
+| `description`              | string | Human-readable description of the resource                             | No       |
+| `category`                 | string | Resource category for organization                                     | No       |
+| `image`                    | string | URL to an icon or logo image                                           | No       |
+| `resource_usage.cpu`       | string | Expected CPU usage (e.g., "500m", "2")                                 | No       |
+| `resource_usage.memory`    | string | Expected memory usage (e.g., "512Mi", "2Gi")                           | No       |
 
 ## Config Fields
 
@@ -61,23 +59,25 @@ The `config` array defines user-configurable parameters. See [Configuration Sche
 
 The `spec` section defines how the custom module container should be deployed and what permissions it has.
 
-| Field | Type | Description | Required |
-|-------|------|-------------|----------|
-| `spec.image` | string | Docker image reference (e.g., `my-registry/my-module:v1.0.0`) | Yes |
-| `spec.imagePullSecrets` | array of strings | List of Kubernetes secret names for pulling private images | No |
-| `spec.permissions` | array of strings | Cluster access permissions. `workspace` = workspace kubeconfig, `controller` = operator service account | No |
+| Field                   | Type             | Description                                                                                             | Required |
+| ----------------------- | ---------------- | ------------------------------------------------------------------------------------------------------- | -------- |
+| `spec.image`            | string           | Docker image reference (e.g., `my-registry/my-module:v1.0.0`)                                           | Yes      |
+| `spec.imagePullSecrets` | array of strings | List of Kubernetes secret names for pulling private images                                              | No       |
+| `spec.permissions`      | array of strings | Cluster access permissions. `workspace` = workspace kubeconfig, `controller` = operator service account | No       |
 
 ### Image
 
 The `image` field specifies the Docker container image that contains your custom module implementation.
 
 **Example:**
+
 ```yaml
 spec:
   image: my-registry/my-module:v1.0.0
 ```
 
 **Note**: The image must be accessible from your Kubernetes cluster. You can use:
+
 - Public registries (Docker Hub, GHCR, etc.)
 - Private registries (requires image pull secrets)
 - Internal registries within your cluster
@@ -87,6 +87,7 @@ spec:
 The `imagePullSecrets` field specifies Kubernetes secrets containing credentials for pulling images from private registries.
 
 **Example:**
+
 ```yaml
 spec:
   image: my-private-registry.com/my-module:v1.0.0
@@ -96,6 +97,7 @@ spec:
 ```
 
 **Creating an image pull secret:**
+
 ```bash
 kubectl create secret docker-registry my-registry-secret \
   --docker-server=my-private-registry.com \
@@ -118,6 +120,7 @@ The `permissions` field specifies what level of cluster access the custom module
 - **`controller`**: Provides the module with access to the main cluster (where the Forkspacer operator is installed) via a service account. The module runs with elevated permissions similar to the operator itself. Use this only for modules that need to manage operator-level resources or interact with multiple workspaces.
 
 **Example with workspace permissions:**
+
 ```yaml
 spec:
   image: my-registry/my-module:v1.0.0
@@ -128,6 +131,7 @@ spec:
 The module will receive the workspace's kubeconfig and can manage resources in that workspace's cluster.
 
 **Example with controller permissions:**
+
 ```yaml
 spec:
   image: my-registry/admin-module:v1.0.0
@@ -148,6 +152,7 @@ Custom modules are containerized HTTP services that implement a REST API for lif
 All custom modules must implement the following HTTP endpoints:
 
 #### Health Check
+
 ```
 GET /health
 Response: 200 OK
@@ -160,6 +165,7 @@ Response: 200 OK
 ```
 
 #### Install
+
 ```
 POST /install
 Content-Type: application/json
@@ -170,6 +176,7 @@ Response: 201 Created (on success) or 400 Bad Request (on failure)
 Called when a Module is created or needs to be installed. This endpoint should deploy and configure all required resources.
 
 #### Uninstall
+
 ```
 POST /uninstall
 Content-Type: application/json
@@ -180,6 +187,7 @@ Response: 204 No Content (on success) or 400 Bad Request (on failure)
 Called when a Module is deleted. This endpoint should remove all resources and clean up.
 
 #### Sleep
+
 ```
 POST /sleep
 Content-Type: application/json
@@ -190,6 +198,7 @@ Response: 200 OK (on success) or 400 Bad Request (on failure)
 Called when a Module is hibernated. This endpoint should scale down or pause resources to save costs.
 
 #### Resume
+
 ```
 POST /resume
 Content-Type: application/json
@@ -750,12 +759,14 @@ Custom modules are distributed as Docker container images. You can host them on:
 ### Public Registries
 
 **Docker Hub:**
+
 ```yaml
 spec:
   image: myusername/my-module:v1.0.0
 ```
 
 **GitHub Container Registry:**
+
 ```yaml
 spec:
   image: ghcr.io/myorg/my-module:v1.0.0
@@ -773,6 +784,7 @@ spec:
 ```
 
 **Create the secret:**
+
 ```bash
 kubectl create secret docker-registry my-registry-secret \
   --docker-server=my-private-registry.com \

--- a/src/content/docs/reference/Resources/helm.md
+++ b/src/content/docs/reference/Resources/helm.md
@@ -2,10 +2,8 @@
 title: Helm
 description: Helm resource definition reference for deploying Helm charts
 sidebar:
-    order: 2
+  order: 2
 ---
-
-# Helm Resources
 
 Helm resources define how Helm charts should be deployed within a Module. They provide a declarative way to specify Helm repositories, chart versions, values, and configuration options.
 
@@ -43,17 +41,17 @@ spec:
 
 ## Metadata Fields
 
-| Field | Type | Description | Required |
-|-------|------|-------------|----------|
-| `name` | string | Unique identifier for the resource | Yes |
-| `version` | string | Semantic version of the resource definition | Yes |
-| `supportedOperatorVersion` | string | Operator version constraint (semver format, e.g., ">= 0.0.0, < 1.0.0") | Yes |
-| `author` | string | Resource author or maintainer | No |
-| `description` | string | Human-readable description of the resource | No |
-| `category` | string | Resource category for organization | No |
-| `image` | string | URL to an icon or logo image | No |
-| `resource_usage.cpu` | string | Expected CPU usage (e.g., "500m", "2") | No |
-| `resource_usage.memory` | string | Expected memory usage (e.g., "512Mi", "2Gi") | No |
+| Field                      | Type   | Description                                                            | Required |
+| -------------------------- | ------ | ---------------------------------------------------------------------- | -------- |
+| `name`                     | string | Unique identifier for the resource                                     | Yes      |
+| `version`                  | string | Semantic version of the resource definition                            | Yes      |
+| `supportedOperatorVersion` | string | Operator version constraint (semver format, e.g., ">= 0.0.0, < 1.0.0") | Yes      |
+| `author`                   | string | Resource author or maintainer                                          | No       |
+| `description`              | string | Human-readable description of the resource                             | No       |
+| `category`                 | string | Resource category for organization                                     | No       |
+| `image`                    | string | URL to an icon or logo image                                           | No       |
+| `resource_usage.cpu`       | string | Expected CPU usage (e.g., "500m", "2")                                 | No       |
+| `resource_usage.memory`    | string | Expected memory usage (e.g., "512Mi", "2Gi")                           | No       |
 
 ## Config Fields
 
@@ -61,16 +59,16 @@ The `config` array defines user-configurable parameters. See [Configuration Sche
 
 ## Spec Fields
 
-| Field | Type | Description | Required |
-|-------|------|-------------|----------|
-| `namespace` | string | Target Kubernetes namespace for the Helm release | Yes |
-| `repo` | string | Helm chart repository URL | Yes |
-| `chartName` | string | Name of the Helm chart in the repository | Yes |
-| `version` | string | Chart version to install | Yes |
-| `values` | array | Array of value sources (raw, file, configMap) | No |
-| `outputs` | array | Output values to expose after installation | No |
-| `cleanup` | object | Cleanup behavior when module is deleted | No |
-| `migration` | object | Data migration configuration for workspace forking | No |
+| Field       | Type   | Description                                        | Required |
+| ----------- | ------ | -------------------------------------------------- | -------- |
+| `namespace` | string | Target Kubernetes namespace for the Helm release   | Yes      |
+| `repo`      | string | Helm chart repository URL                          | Yes      |
+| `chartName` | string | Name of the Helm chart in the repository           | Yes      |
+| `version`   | string | Chart version to install                           | Yes      |
+| `values`    | array  | Array of value sources (raw, file, configMap)      | No       |
+| `outputs`   | array  | Output values to expose after installation         | No       |
+| `cleanup`   | object | Cleanup behavior when module is deleted            | No       |
+| `migration` | object | Data migration configuration for workspace forking | No       |
 
 ### Values Sources
 
@@ -157,8 +155,8 @@ Configure cleanup behavior when the module is deleted:
 
 ```yaml
 cleanup:
-  removeNamespace: false  # Whether to remove the namespace
-  removePVCs: true        # Whether to remove PersistentVolumeClaims
+  removeNamespace: false # Whether to remove the namespace
+  removePVCs: true # Whether to remove PersistentVolumeClaims
 ```
 
 ### Migration
@@ -168,31 +166,31 @@ Configure data migration behavior for workspace forking. When a workspace is for
 ```yaml
 migration:
   pvc:
-    enabled: true  # Enable PVC migration for this module
-    names:         # List of PVC names to migrate (supports templating)
+    enabled: true # Enable PVC migration for this module
+    names: # List of PVC names to migrate (supports templating)
       - "data-{{ .releaseName }}-0"
       - "logs-{{ .releaseName }}-0"
   secret:
-    enabled: true  # Enable Secret migration for this module
-    names:         # List of Secret names to migrate (supports templating)
+    enabled: true # Enable Secret migration for this module
+    names: # List of Secret names to migrate (supports templating)
       - "{{ .releaseName }}"
       - "{{ .releaseName }}-tls"
   configMap:
-    enabled: true  # Enable ConfigMap migration for this module
-    names:         # List of ConfigMap names to migrate (supports templating)
+    enabled: true # Enable ConfigMap migration for this module
+    names: # List of ConfigMap names to migrate (supports templating)
       - "{{ .releaseName }}-config"
 ```
 
 **Fields:**
 
-| Field | Type | Description | Required |
-|-------|------|-------------|----------|
-| `pvc.enabled` | boolean | Enable PVC migration for this Helm module | No (default: `false`) |
-| `pvc.names` | array of strings | List of PVC names to migrate. Supports Go templating with `.releaseName` and `.config.*` variables. | Yes (when `pvc.enabled` is true) |
-| `secret.enabled` | boolean | Enable Secret migration for this Helm module | No (default: `false`) |
-| `secret.names` | array of strings | List of Secret names to migrate. Supports Go templating with `.releaseName` and `.config.*` variables. | Yes (when `secret.enabled` is true) |
-| `configMap.enabled` | boolean | Enable ConfigMap migration for this Helm module | No (default: `false`) |
-| `configMap.names` | array of strings | List of ConfigMap names to migrate. Supports Go templating with `.releaseName` and `.config.*` variables. | Yes (when `configMap.enabled` is true) |
+| Field               | Type             | Description                                                                                               | Required                               |
+| ------------------- | ---------------- | --------------------------------------------------------------------------------------------------------- | -------------------------------------- |
+| `pvc.enabled`       | boolean          | Enable PVC migration for this Helm module                                                                 | No (default: `false`)                  |
+| `pvc.names`         | array of strings | List of PVC names to migrate. Supports Go templating with `.releaseName` and `.config.*` variables.       | Yes (when `pvc.enabled` is true)       |
+| `secret.enabled`    | boolean          | Enable Secret migration for this Helm module                                                              | No (default: `false`)                  |
+| `secret.names`      | array of strings | List of Secret names to migrate. Supports Go templating with `.releaseName` and `.config.*` variables.    | Yes (when `secret.enabled` is true)    |
+| `configMap.enabled` | boolean          | Enable ConfigMap migration for this Helm module                                                           | No (default: `false`)                  |
+| `configMap.names`   | array of strings | List of ConfigMap names to migrate. Supports Go templating with `.releaseName` and `.config.*` variables. | Yes (when `configMap.enabled` is true) |
 
 **How Migration Works:**
 
@@ -239,7 +237,7 @@ spec:
     secret:
       enabled: true
       names:
-        - "{{ .releaseName }}"  # Migrates the Redis password secret
+        - "{{ .releaseName }}" # Migrates the Redis password secret
 ```
 
 **Example with Redis (Master + Replicas):**
@@ -282,11 +280,11 @@ spec:
     secret:
       enabled: true
       names:
-        - "{{ .releaseName }}"  # Migrates PostgreSQL password secret
+        - "{{ .releaseName }}" # Migrates PostgreSQL password secret
     configMap:
       enabled: true
       names:
-        - "{{ .releaseName }}-configuration"  # Migrates PostgreSQL configuration
+        - "{{ .releaseName }}-configuration" # Migrates PostgreSQL configuration
 ```
 
 ## Templating
@@ -507,7 +505,7 @@ spec:
     secret:
       enabled: true
       names:
-        - "{{ .releaseName }}"  # Migrates Redis password secret
+        - "{{ .releaseName }}" # Migrates Redis password secret
 ```
 
 ## Usage in Modules
@@ -581,6 +579,7 @@ When using the `file` option for Helm values, the files must be hosted on access
 ### Hosting Options
 
 **Static File Server:**
+
 ```bash
 # Serve values files via HTTP
 cd helm-values
@@ -590,12 +589,14 @@ python3 -m http.server 8080
 ```
 
 **Object Storage:**
+
 - Amazon S3
 - Google Cloud Storage
 - Azure Blob Storage
 - MinIO
 
 **Web Server:**
+
 - Nginx
 - Apache
 - GitHub Releases/Raw
@@ -603,18 +604,21 @@ python3 -m http.server 8080
 ### Example Distribution
 
 **Hosting on GitHub Raw:**
+
 ```yaml
 values:
   - file: https://raw.githubusercontent.com/org/repo/main/helm-values/production.yaml
 ```
 
 **Hosting on Object Storage:**
+
 ```yaml
 values:
   - file: https://storage.googleapis.com/my-bucket/helm-values/production.yaml
 ```
 
 **Hosting on CDN:**
+
 ```yaml
 values:
   - file: https://cdn.example.com/helm-values/v1.0.0/production.yaml

--- a/src/content/docs/reference/Resources/overview.md
+++ b/src/content/docs/reference/Resources/overview.md
@@ -5,7 +5,7 @@ sidebar:
   order: 1
 ---
 
-# Resources Overview
+# Resources
 
 Resources are YAML definition files that describe how modules should be installed and configured within a workspace. They provide a declarative way to define Helm charts or custom modules with user-configurable parameters.
 
@@ -24,6 +24,7 @@ The forkspacer operator supports two types of resources:
 - Cleanup policies
 
 **Use Cases:**
+
 - Deploying standard applications from Helm charts
 - Database deployments (PostgreSQL, MySQL, Redis, etc.)
 - Monitoring stacks (Prometheus, Grafana)
@@ -42,6 +43,7 @@ The forkspacer operator supports two types of resources:
 - Support for hibernation and resume operations
 
 **Use Cases:**
+
 - Custom application installations requiring complex logic
 - Advanced Kubernetes resource management
 - Integration with external systems and APIs
@@ -72,25 +74,24 @@ config:
     name: <config-name>
     alias: <config-alias>
     spec: <type-specific-spec>
-spec:
-  <kind-specific-spec>
+spec: <kind-specific-spec>
 ```
 
 ## Metadata
 
 Resource metadata provides information about the resource definition:
 
-| Field | Description | Required |
-|-------|-------------|----------|
-| `name` | Unique identifier for the resource | Yes |
-| `version` | Semantic version of the resource definition | Yes |
-| `supportedOperatorVersion` | Operator version constraint (e.g., ">= 0.0.0, < 1.0.0", "~1.2.0") | Yes |
-| `author` | Resource maintainer or author | No |
-| `description` | Human-readable description | No |
-| `category` | Resource category for organization | No |
-| `image` | Icon or logo URL | No |
-| `resource_usage.cpu` | Expected CPU usage (e.g., "500m") | No |
-| `resource_usage.memory` | Expected memory usage (e.g., "1Gi") | No |
+| Field                      | Description                                                       | Required |
+| -------------------------- | ----------------------------------------------------------------- | -------- |
+| `name`                     | Unique identifier for the resource                                | Yes      |
+| `version`                  | Semantic version of the resource definition                       | Yes      |
+| `supportedOperatorVersion` | Operator version constraint (e.g., ">= 0.0.0, < 1.0.0", "~1.2.0") | Yes      |
+| `author`                   | Resource maintainer or author                                     | No       |
+| `description`              | Human-readable description                                        | No       |
+| `category`                 | Resource category for organization                                | No       |
+| `image`                    | Icon or logo URL                                                  | No       |
+| `resource_usage.cpu`       | Expected CPU usage (e.g., "500m")                                 | No       |
+| `resource_usage.memory`    | Expected memory usage (e.g., "1Gi")                               | No       |
 
 **Version Constraints:**
 
@@ -128,6 +129,7 @@ Text values with optional regex validation:
 ```
 
 **Spec Fields:**
+
 - `required` (boolean): Whether the field is required
 - `default` (string): Default value
 - `regex` (string): Validation regex pattern
@@ -150,6 +152,7 @@ Numeric values with optional min/max constraints:
 ```
 
 **Spec Fields:**
+
 - `required` (boolean): Whether the field is required
 - `default` (integer): Default value
 - `min` (integer): Minimum allowed value
@@ -173,6 +176,7 @@ Floating-point values with optional min/max constraints:
 ```
 
 **Spec Fields:**
+
 - `required` (boolean): Whether the field is required
 - `default` (float): Default value
 - `min` (float): Minimum allowed value
@@ -194,6 +198,7 @@ True/false values:
 ```
 
 **Spec Fields:**
+
 - `required` (boolean): Whether the field is required
 - `default` (boolean): Default value
 - `editable` (boolean): Whether users can modify this value
@@ -217,6 +222,7 @@ Single selection from predefined values:
 ```
 
 **Spec Fields:**
+
 - `required` (boolean): Whether the field is required
 - `default` (string): Default value (must be in values list)
 - `values` (array): List of allowed values
@@ -245,6 +251,7 @@ Multiple selections from predefined values:
 ```
 
 **Spec Fields:**
+
 - `required` (boolean): Whether the field is required
 - `default` (array): Default values (must be in values list)
 - `values` (array): List of allowed values


### PR DESCRIPTION
- Add Introduction section with 'What is Forkspacer' and Core Concepts pages
- Reorganize homepage cards for better flow (show examples first, then explain)
- Add context to Quick Start explaining module definitions
- Simplify Helm installation instructions
- Update navigation to include Introduction as first section